### PR TITLE
1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,46 @@ scrape-youtube
   
  **What is this?***
 ------------------
-Scrape information from youtube search results. This was made for Discord Bots but can be used for whatever.  
+A [lightning fast](https://i.imgur.com/ipsWhkv.png) package to scrape YouTube search results. This was made and optimized for Discord Bots. 
   
-Basic Use
----------------------
+#### Install  
+```npm install scrape-youtube```
 
-Require the package 
+#### Require 
 ```javascript
 import youtube from 'scrape-youtube';
+// const youtube = require('scrape-youtube').default;
 ```
 
-Then you're good to go.  
-
+#### Search  
 ```javascript
 youtube.search('Short Change Hero').then(results => {
     console.log(results)
 });
-// To quickly get one result: 
-// youtube.searchOne('Short Change Hero').then(...)
 ```
 
-## Example Response (video)
+#### Example Response
+This is the structure of a single result. The search function will return an array of up to 20 results.
 ```json
 {
-  "type": "video",
-  "channel": {
-    "name": "Magloire Lamine",
-    "link": "https://youtube.com/user/TENESANGO",
-    "verified": false
-  },
   "id": "lkvScx3Po8I",
   "title": "The Heavy - Short Change Hero",
   "link": "https://www.youtube.com/watch?v=lkvScx3Po8I",
-  "description": "... long description ...",     
+  "description": "... long description ...",   
   "thumbnail": "https://i.ytimg.com/vi/lkvScx3Po8I/hqdefault.jpg",
-  "duration": 238,
+  "channel": {
+    "name": "Magloire Lamine",
+    "link": "https://youtube.com/user/TENESANGO",
+    "verified": false,
+    "thumbnail": "https://yt3.ggpht.com/a/AATXAJz3kOe_LDvhRWpQLu1wHb5xU7HNOKvpKQnLQA=s88-c-k-c0xffffffff-no-rj-mo"
+  },  
   "views": 7960221,
+  "duration": 238,
   "uploaded": "6 years ago"
 }
 ```  
 
-Other result types (like playlists and and live streams) are unsupported in this version. They will be re-added in the future, When I get more time.  
+#### Notes
+- Currently additional types like playlists, live streams and movies are unsupported. These will be re-added in some time.  
+- You can load another page by passing `{ page: 1 }` as the second parameter.
+

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,8 +1,0 @@
-import youtube from '../src';
-// import youtube from 'scrape-youtube';
-
-// Quick search for a single video. Good for discord bots.
-youtube.searchOne('Short Change Hero').then(video => console.log(video));
-
-// You can also pass a URL to the searchOne function and ytdl-core will fetch the video information.
-youtube.searchOne('https://www.youtube.com/watch?v=xh49HehENPE').then(video => console.log(video));

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,114 +1,25 @@
-import request = require('request');
-export declare enum ResultType {
-    any = "any",
-    video = "video",
-    channel = "channel",
-    playlist = "playlist",
-    movie = "movie",
-    live = "live"
-}
-export declare const ResultFilter: {
-    [key in ResultType]: string;
-};
-export interface SearchOptions {
-    query: string;
-    type: ResultType | string;
-    page: number;
-    limit: number;
-}
-export interface SearchResult {
-    type: ResultType;
-    channel: {
-        name: string;
-        link: string;
-        verified: boolean;
-    };
-    id: string;
-    title: string;
-    link: string;
-    description: string;
-    thumbnail: string;
-    duration?: number;
-    watching?: number;
-    views?: number;
-    uploaded?: string;
-    videoCount?: number;
-}
-export declare class Youtube {
-    host: string;
-    detectLinks: boolean;
+import { SearchOptions, Video } from './interface';
+declare class Youtube {
     constructor();
+    private getURL;
+    private extractRenderData;
     /**
-     * Generates a request URL using the search options provided.
-     * @param params SearchOptions
+     * Parse the data extracted from the page to match each interface
+     * @param data Video Renderer Data
      */
-    private getRequestURL;
+    private parseData;
     /**
-     * Converts an object into a browser query string.
-     * { one: 'two' } becomes ?one=two
-     * @param o Object
-     */
-    private querystring;
-    /**
-     * Generate video thumbnail
-     * @param id Youtube video ID
-     */
-    private getThumbnail;
-    /**
-     * Convert an hh:mm:ss string into total seconds
-     * @param text hh:mm:ss string
-     */
-    private parseDuration;
-    /**
-     * Convert a string into a number.
-     * @param s string
-     */
-    private num;
-    /**
-     * Compresses the "runs" texts into a single string.
-     * @param key vRender key
-     */
-    private compress;
-    /**
-     * Fetch channel badges and check if they are verified channels
-     * @param vRender vRender
-     */
-    private isChannelVerified;
-    /**
-     * Extract channel data from the vRender object
-     * @param vRender vRender
-     */
-    private getChannelData;
-    private getDuration;
-    private getViews;
-    private getUploadedDate;
-    /**
-     * Load a url and begin scraping the data.
-     * @param url Youtube URL
-     * @param params SearchOptions
-     * @param options request.Options
+     * Load the page and scrape the data
+     * @param query Search query
+     * @param options Search options
      */
     private load;
-    private extractInitialData;
     /**
-     * Search youtube for results.
-     * Result type defaults to 'video'. See advanced use for more information
+     * Search YouTube for a list of videos
      * @param query Search Query
-     * @param options Search Options
-     * @param requestOptions request.Options
+     * @param options Optional Search Options
      */
-    search(query: string, options?: Partial<SearchOptions>, requestOptions?: request.Options): Promise<SearchResult[]>;
-    /**
-     * Fetches video information using the ytdl-core package, then generates a SearchResult
-     * @param query Youtube URL
-     */
-    private ytdlSearch;
-    /**
-     * Lazy shortcut to get the first result. Probably useful with discord bots.
-     * @param query Search String
-     * @param options request.Options
-     */
-    searchOne(query: string, requestOptions?: request.Options): Promise<SearchResult | null>;
+    search(query: string, options?: SearchOptions): Promise<Video[]>;
 }
 declare const youtube: Youtube;
 export default youtube;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,4 @@
 "use strict";
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -46,325 +35,125 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _a;
 Object.defineProperty(exports, "__esModule", { value: true });
-var request = require("request");
-var cheerio = require("cheerio");
-var ytdl = require("ytdl-core");
-var ResultType;
-(function (ResultType) {
-    ResultType["any"] = "any";
-    ResultType["video"] = "video";
-    ResultType["channel"] = "channel";
-    ResultType["playlist"] = "playlist";
-    ResultType["movie"] = "movie";
-    ResultType["live"] = "live";
-})(ResultType = exports.ResultType || (exports.ResultType = {}));
-exports.ResultFilter = (_a = {},
-    _a[ResultType.any] = 'CAA%253D',
-    _a[ResultType.video] = 'EgIQAQ%253D%253D',
-    _a[ResultType.channel] = 'EgIQAg%253D%253D',
-    _a[ResultType.playlist] = 'EgIQAw%253D%253D',
-    _a[ResultType.movie] = 'EgIQBA%253D%253D',
-    _a[ResultType.live] = 'EgJAAQ%253D%253D',
-    _a);
+var https_1 = require("https");
+var interface_1 = require("./interface");
+var parser_1 = require("./parser");
 var Youtube = /** @class */ (function () {
     function Youtube() {
-        this.host = 'https://www.youtube.com';
-        this.detectLinks = false;
     }
-    /**
-     * Generates a request URL using the search options provided.
-     * @param params SearchOptions
-     */
-    Youtube.prototype.getRequestURL = function (params) {
-        return (this.host + "/results" +
-            this.querystring({
-                search_query: encodeURIComponent(params.query),
-                page: params.page,
-                sp: exports.ResultFilter[params.type]
-            }));
+    Youtube.prototype.getURL = function (query, options) {
+        var _a;
+        var url = new URL('/results', 'https://www.youtube.com');
+        url.search = new URLSearchParams({
+            search_query: query,
+            sp: interface_1.ResultFilter[(options.type || 'video')],
+            page: "" + ((_a = options.page) !== null && _a !== void 0 ? _a : 0)
+        }).toString();
+        return url.href;
     };
-    /**
-     * Converts an object into a browser query string.
-     * { one: 'two' } becomes ?one=two
-     * @param o Object
-     */
-    Youtube.prototype.querystring = function (o) {
-        return Object.keys(o).map(function (v, i) { return (i !== 0 ? '&' : '?') + (v + "=" + o[v]); }).join('');
-    };
-    /**
-     * Generate video thumbnail
-     * @param id Youtube video ID
-     */
-    Youtube.prototype.getThumbnail = function (id) {
-        return "https://i.ytimg.com/vi/" + id + "/hqdefault.jpg";
-    };
-    /**
-     * Convert an hh:mm:ss string into total seconds
-     * @param text hh:mm:ss string
-     */
-    Youtube.prototype.parseDuration = function (text) {
-        var nums = text.split(':');
-        var sum = 0;
-        var multi = 1;
-        while (nums.length > 0) {
-            sum += multi * parseInt(nums.pop() || '-1', 10);
-            multi *= 60;
-        }
-        return sum;
-    };
-    /**
-     * Convert a string into a number.
-     * @param s string
-     */
-    Youtube.prototype.num = function (s) {
-        return +("" + s).replace(/[^0-9.]/g, '');
-    };
-    /**
-     * Compresses the "runs" texts into a single string.
-     * @param key vRender key
-     */
-    Youtube.prototype.compress = function (key) {
-        return (key && key['runs'] ?
-            key['runs'].map(function (v) { return v.text; }) : []).join('');
-    };
-    /**
-     * Fetch channel badges and check if they are verified channels
-     * @param vRender vRender
-     */
-    Youtube.prototype.isChannelVerified = function (vRender) {
-        var badges = (vRender['ownerBadges'] ?
-            vRender['ownerBadges'].map(function (badge) { return badge['metadataBadgeRenderer']['style']; }) : []);
-        return badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST');
-    };
-    /**
-     * Extract channel data from the vRender object
-     * @param vRender vRender
-     */
-    Youtube.prototype.getChannelData = function (vRender) {
-        var channel = vRender['ownerText']['runs'][0];
-        return {
-            name: channel['text'],
-            link: ('https://youtube.com' +
-                channel['navigationEndpoint']['commandMetadata']['webCommandMetadata']['url']),
-            verified: this.isChannelVerified(vRender)
-        };
-    };
-    Youtube.prototype.getDuration = function (vRender) {
-        return this.parseDuration(vRender['lengthText']['simpleText']);
-    };
-    Youtube.prototype.getViews = function (vRender) {
-        return this.num(vRender['viewCountText']['simpleText']);
-    };
-    Youtube.prototype.getUploadedDate = function (vRender) {
-        // Sometimes publishedTimeText is not available.
-        // EG: https://i.imgur.com/cR1na6k.png
-        return vRender['publishedTimeText'] ? vRender['publishedTimeText']['simpleText'] : '';
-    };
-    /**
-     * Load a url and begin scraping the data.
-     * @param url Youtube URL
-     * @param params SearchOptions
-     * @param options request.Options
-     */
-    Youtube.prototype.load = function (url, params, options) {
-        var _this = this;
-        return new Promise(function (resolve, reject) {
-            request(__assign({ method: 'GET', url: url }, (options || {})), function (err, res, body) { return __awaiter(_this, void 0, void 0, function () {
-                var results_1, $, data, e_1;
-                var _this = this;
-                return __generator(this, function (_a) {
-                    switch (_a.label) {
-                        case 0:
-                            if (err)
-                                return [2 /*return*/, reject(err)];
-                            _a.label = 1;
-                        case 1:
-                            _a.trys.push([1, 3, , 4]);
-                            results_1 = [];
-                            $ = cheerio.load(body);
-                            return [4 /*yield*/, this.extractInitialData($)];
-                        case 2:
-                            data = _a.sent();
-                            data.forEach(function (item) {
-                                try {
-                                    var vRender = item['videoRenderer'];
-                                    if (vRender) {
-                                        var id = vRender['videoId'];
-                                        // TODO: Add multiple types again
-                                        var result = {
-                                            type: ResultType.video,
-                                            channel: _this.getChannelData(vRender),
-                                            id: id,
-                                            title: _this.compress(vRender['title']),
-                                            link: "https://www.youtube.com/watch?v=" + id,
-                                            description: _this.compress(vRender['descriptionSnippet']),
-                                            thumbnail: _this.getThumbnail(id),
-                                            views: _this.getViews(vRender),
-                                            duration: _this.getDuration(vRender),
-                                            uploaded: _this.getUploadedDate(vRender)
-                                        };
-                                        results_1.push(result);
-                                    }
-                                }
-                                catch (e) {
-                                    console.log(e);
-                                }
-                            });
-                            resolve(results_1);
-                            return [3 /*break*/, 4];
-                        case 3:
-                            e_1 = _a.sent();
-                            reject(e_1);
-                            return [3 /*break*/, 4];
-                        case 4: return [2 /*return*/];
-                    }
-                });
-            }); });
-        });
-    };
-    Youtube.prototype.extractInitialData = function ($) {
+    Youtube.prototype.extractRenderData = function (page) {
         return new Promise(function (resolve, reject) {
             try {
-                var json_1 = null;
-                $('script').each(function (i, script) {
-                    var html = $(script).html();
-                    if (html && html.includes('ytInitialData')) {
-                        var start = (html.split('var ytInitialData = ').pop() || '');
-                        var end = start.split('\n').shift();
-                        if (end) {
-                            json_1 = JSON.parse("" + end.replace(/;/g, ''));
-                            // Unavoidable Ladder
-                            resolve(json_1.contents
-                                .twoColumnSearchResultsRenderer
-                                .primaryContents
-                                .sectionListRenderer
-                                .contents[0]
-                                .itemSectionRenderer
-                                .contents);
-                        }
-                        else
-                            throw Error('Failed to extract InitialData');
-                    }
-                });
-                if (!json_1) {
-                    throw Error('Failed to extract InitialData. The request may have been blocked.');
-                }
+                // Last update they actually commented it as scraper data.
+                var data = page.split('// scraper_data_begin')[1].trim()
+                    .split('// scraper_data_end')[0].trim()
+                    .slice(0, -1)
+                    .slice('var ytInitialData = '.length);
+                resolve(JSON.parse(data).contents
+                    .twoColumnSearchResultsRenderer
+                    .primaryContents
+                    .sectionListRenderer
+                    .contents[0]
+                    .itemSectionRenderer
+                    .contents);
             }
             catch (e) {
-                reject(e);
+                console.log(e);
+                reject('Failed to extract video data. The request may have been blocked');
             }
         });
     };
     /**
-     * Search youtube for results.
-     * Result type defaults to 'video'. See advanced use for more information
-     * @param query Search Query
-     * @param options Search Options
-     * @param requestOptions request.Options
+     * Parse the data extracted from the page to match each interface
+     * @param data Video Renderer Data
      */
-    Youtube.prototype.search = function (query, options, requestOptions) {
-        var _this = this;
-        return new Promise(function (resolve, reject) { return __awaiter(_this, void 0, void 0, function () {
-            var params, url;
-            return __generator(this, function (_a) {
-                params = __assign({ query: query.trim(), page: 0, type: ResultType.video, limit: 10 }, options);
-                if (params.query.length === 0) {
-                    return [2 /*return*/, reject(new Error('Search cannot be blank'))];
-                }
-                if (params.type !== ResultType.video) {
-                    params.type = ResultType.video;
-                    console.warn('Search type must be `video`. Other types are unsupported in this version but will be re-added in the future');
-                }
-                if (!Object.keys(ResultType).includes(params.type)) {
-                    return [2 /*return*/, reject(new Error("Unexpected result type: " + params.type))];
-                }
-                if (params.page < 0) {
-                    return [2 /*return*/, reject(new Error("Page number can not be lower than 0"))];
-                }
-                if (params.limit <= 0) {
-                    return [2 /*return*/, reject(new Error('Limit can not be lower than 1'))];
-                }
-                url = this.getRequestURL(params);
-                this.load(url, params, requestOptions).then(resolve).catch(reject);
-                return [2 /*return*/];
-            });
-        }); });
+    Youtube.prototype.parseData = function (data) {
+        return new Promise(function (resolve, reject) {
+            try {
+                var results_1 = [];
+                data.forEach(function (item) {
+                    var vRender = item['videoRenderer'];
+                    if (!vRender)
+                        return;
+                    try {
+                        var result = parser_1.getVideoData(vRender);
+                        results_1.push(result);
+                    }
+                    catch (e) {
+                        console.log(e);
+                    }
+                    resolve(results_1);
+                });
+            }
+            catch (e) {
+                console.warn(e);
+                reject('Fatal error when parsing result data. Please report this on GitHub');
+            }
+        });
     };
     /**
-     * Fetches video information using the ytdl-core package, then generates a SearchResult
-     * @param query Youtube URL
+     * Load the page and scrape the data
+     * @param query Search query
+     * @param options Search options
      */
-    Youtube.prototype.ytdlSearch = function (query) {
+    Youtube.prototype.load = function (query, options) {
+        var url = this.getURL(query, options);
+        return new Promise(function (resolve, reject) {
+            https_1.get(url, function (res) {
+                res.setEncoding('utf8');
+                var data = '';
+                res.on('data', function (chunk) { return data += chunk; });
+                res.on('end', function () { return resolve(data); });
+            }).on('error', reject);
+        });
+    };
+    /**
+     * Search YouTube for a list of videos
+     * @param query Search Query
+     * @param options Optional Search Options
+     */
+    Youtube.prototype.search = function (query, options) {
         var _this = this;
+        if (options === void 0) { options = {}; }
         return new Promise(function (resolve, reject) { return __awaiter(_this, void 0, void 0, function () {
-            var vdata, details, preview, e_2;
+            var page, data, results, e_1;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        _a.trys.push([0, 2, , 3]);
-                        return [4 /*yield*/, ytdl.getInfo(query)];
+                        _a.trys.push([0, 4, , 5]);
+                        return [4 /*yield*/, this.load(query, options)];
                     case 1:
-                        vdata = _a.sent();
-                        if (vdata && vdata.videoDetails) {
-                            details = vdata.videoDetails;
-                            preview = {
-                                type: ResultType.video,
-                                channel: {
-                                    name: details.author.name,
-                                    link: details.author.user_url,
-                                    verified: details.author.verified
-                                },
-                                id: details.videoId,
-                                title: details.title,
-                                link: "https://www.youtube.com/watch?v=" + details.videoId,
-                                description: details.shortDescription,
-                                thumbnail: this.getThumbnail(details.videoId),
-                                duration: +details.lengthSeconds,
-                                views: +details.viewCount
-                            };
-                            resolve(preview);
-                        }
-                        else
-                            throw new Error('Failed to load video details');
-                        return [3 /*break*/, 3];
+                        page = _a.sent();
+                        return [4 /*yield*/, this.extractRenderData(page)];
                     case 2:
-                        e_2 = _a.sent();
-                        reject(e_2);
-                        return [3 /*break*/, 3];
-                    case 3: return [2 /*return*/];
+                        data = _a.sent();
+                        require('fs').writeFileSync('debug.json', JSON.stringify(data, null, 2));
+                        return [4 /*yield*/, this.parseData(data)];
+                    case 3:
+                        results = _a.sent();
+                        resolve(results);
+                        return [3 /*break*/, 5];
+                    case 4:
+                        e_1 = _a.sent();
+                        reject(e_1);
+                        return [3 /*break*/, 5];
+                    case 5: return [2 /*return*/];
                 }
-            });
-        }); });
-    };
-    /**
-     * Lazy shortcut to get the first result. Probably useful with discord bots.
-     * @param query Search String
-     * @param options request.Options
-     */
-    Youtube.prototype.searchOne = function (query, requestOptions) {
-        var _this = this;
-        return new Promise(function (resolve, reject) { return __awaiter(_this, void 0, void 0, function () {
-            return __generator(this, function (_a) {
-                // Detect if input is already a video URL. This
-                // should save some time when it comes to discord
-                // bots
-                if (ytdl.validateURL(query)) {
-                    this.ytdlSearch(query).then(resolve).catch(reject);
-                }
-                else {
-                    this.search(query, { type: ResultType.video, limit: 1 }, requestOptions).then(function (results) {
-                        resolve(results.length ? results[0] : null);
-                    }).catch(reject);
-                }
-                return [2 /*return*/];
             });
         }); });
     };
     return Youtube;
 }());
-exports.Youtube = Youtube;
-/* For quick use without creating a new instance */
 var youtube = new Youtube();
 exports.default = youtube;

--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -1,0 +1,44 @@
+export declare enum ResultType {
+    any = "any",
+    video = "video",
+    channel = "channel",
+    playlist = "playlist",
+    movie = "movie",
+    live = "live"
+}
+export interface SearchOptions {
+    type?: ResultType;
+    page?: number;
+}
+export declare const ResultFilter: {
+    [key in ResultType]: string;
+};
+export interface Channel {
+    name: string;
+    link: string;
+    verified: boolean;
+    thumbnail: string;
+}
+export interface Result {
+    /** Video or Playlist ID */
+    id: string;
+    title: string;
+    link: string;
+    description: string;
+    thumbnail: string;
+    channel: Channel;
+}
+export interface LiveStream extends Result {
+    watching: number;
+}
+export interface Video extends Result {
+    views: number;
+    /** Sometimes the upload date is not available. YouTube is to blame, not this package. */
+    uploaded: string;
+    /** Duration in seconds */
+    duration: number;
+}
+export interface Playlist extends Result {
+    videoCount: number;
+    videos: Video[];
+}

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -1,0 +1,20 @@
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+var ResultType;
+(function (ResultType) {
+    ResultType["any"] = "any";
+    ResultType["video"] = "video";
+    ResultType["channel"] = "channel";
+    ResultType["playlist"] = "playlist";
+    ResultType["movie"] = "movie";
+    ResultType["live"] = "live";
+})(ResultType = exports.ResultType || (exports.ResultType = {}));
+exports.ResultFilter = (_a = {},
+    _a[ResultType.any] = 'CAA%253D',
+    _a[ResultType.video] = 'EgIQAQ%253D%253D',
+    _a[ResultType.channel] = 'EgIQAg%253D%253D',
+    _a[ResultType.playlist] = 'EgIQAw%253D%253D',
+    _a[ResultType.movie] = 'EgIQBA%253D%253D',
+    _a[ResultType.live] = 'EgJAAQ%253D%253D',
+    _a);

--- a/lib/parser.d.ts
+++ b/lib/parser.d.ts
@@ -1,0 +1,11 @@
+import { Channel, Video } from './interface';
+/**
+ * Fetch basic information about the channel
+ * @param video Video Renderer
+ */
+export declare const getChannelData: (video: any) => Channel;
+/**
+ * Extract all information required for the "Video" result type
+ * @param result Video Renderer
+ */
+export declare const getVideoData: (result: any) => Video;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,0 +1,128 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Fetch all badges the channel has
+ * @param video Video Renderer
+ */
+var getChannelBadges = function (video) {
+    var ownerBadges = video.ownerBadges;
+    return ownerBadges ? ownerBadges.map(function (badge) { return badge['metadataBadgeRenderer']; }) : [];
+};
+/**
+ * Attempt to find out if the channel is verified
+ * @param video Video Renderer
+ */
+var isVerified = function (video) {
+    var badges = getChannelBadges(video);
+    return (badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST') ||
+        badges.includes('BADGE_STYLE_TYPE_VERIFIED'));
+};
+/**
+ * Attempt to fetch channel link
+ * @param channel Channel Renderer
+ */
+var getChannelLink = function (channel) {
+    return 'https://www.youtube.com' + (channel.navigationEndpoint.browseEndpoint.canonicalBaseUrl ||
+        channel.navigationEndpoint.commandMetadata.webCommandMetadata.url);
+};
+/**
+ * Compresses the "runs" texts into a single string.
+ * @param key Video Renderer key
+ */
+var compress = function (key) {
+    return (key && key['runs'] ? key['runs'].map(function (v) { return v.text; }) : []).join('');
+};
+/**
+ * Parse an hh:mm:ss timestamp into total seconds
+ * @param text hh:mm:ss
+ */
+var parseDuration = function (text) {
+    var nums = text.split(':');
+    var sum = 0;
+    var multi = 1;
+    while (nums.length > 0) {
+        sum += multi * parseInt(nums.pop() || '-1', 10);
+        multi *= 60;
+    }
+    return sum;
+};
+/**
+ * Sometimes the upload date is not available. YouTube is to blame, not this package.
+ * @param video Video Renderer
+ */
+var getUploadDate = function (video) {
+    return video.publishedTimeText ? video.publishedTimeText.simpleText : '';
+};
+var getViews = function (video) {
+    return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+};
+/**
+ * Attempt to fetch the channel thumbnail
+ * @param video Channel Renderer
+ */
+var getChannelThumbnail = function (video) {
+    return video.channelThumbnailSupportedRenderers
+        .channelThumbnailWithLinkRenderer
+        .thumbnail
+        .thumbnails[0].url;
+};
+var getVideoThumbnail = function (id) {
+    return "https://i.ytimg.com/vi/" + id + "/hqdefault.jpg";
+};
+/**
+ * Fetch a video or playlist link using the supplied ID
+ * @param id ID
+ * @param playlist is playlist true/false
+ */
+var getLink = function (id, playlist) {
+    return (playlist ? 'https://www.youtube.com/playlist?list=' : 'https://youtu.be/') + id;
+};
+/**
+ * Fetch basic information about the channel
+ * @param video Video Renderer
+ */
+exports.getChannelData = function (video) {
+    var channel = video.ownerText.runs[0];
+    return {
+        name: channel.text,
+        link: getChannelLink(channel),
+        verified: isVerified(video),
+        thumbnail: getChannelThumbnail(video)
+    };
+};
+/**
+ * Fetch the default result data included in all result types
+ * @param result Video Renderer
+ */
+var getResultData = function (result) {
+    return {
+        id: result.videoId,
+        title: compress(result.title),
+        link: getLink(result.videoId, false),
+        description: compress(result.descriptionSnippet),
+        thumbnail: getVideoThumbnail(result.videoId),
+        channel: exports.getChannelData(result)
+    };
+};
+/**
+ * Extract all information required for the "Video" result type
+ * @param result Video Renderer
+ */
+exports.getVideoData = function (result) {
+    return __assign(__assign({}, getResultData(result)), { views: getViews(result), uploaded: getUploadDate(result), duration: parseDuration(result.lengthText.simpleText) });
+};
+// TODO: These ↓
+// const getPlaylistData = (result: any): Playlist => { };
+// const getSteamData = (result: any): LiveSteam => { };
+// const getMovieData = (result: any): Movie => { };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scrape-youtube",
-  "version": "0.2.4",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,55 +30,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
-    "@types/cheerio": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.18.tgz",
-      "integrity": "sha512-Fq7R3fINAPSdUEhOyjG4iVxgHrOnqDJbY0/BUuiN0pvD/rfmZWekVZnv+vcs8TtpA2XF50uv50LaE4EnpEL/Hw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "13.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
-    },
-    "@types/request": {
-      "version": "2.48.4",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
-      "dev": true,
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      }
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-      "dev": true
-    },
-    "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -97,52 +48,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -160,11 +70,6 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -174,19 +79,6 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      }
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-      "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
       }
     },
     "color-convert": {
@@ -204,14 +96,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -224,90 +108,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
-    },
-    "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -321,55 +126,11 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.1.6",
@@ -385,53 +146,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
-    },
-    "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -446,17 +165,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -473,69 +183,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "m3u8stream": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.0.tgz",
-      "integrity": "sha512-vvSjdkBPdDHzVr2M+aIXbnYys4zX6m3UzxMaxBJr1PpE0e/3sawkLD4EEmz/q9hv87bleotR70cOWR3UBMtskw==",
-      "requires": {
-        "miniget": "^2.0.1",
-        "sax": "^1.2.4"
-      }
-    },
-    "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-    },
-    "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "requires": {
-        "mime-db": "1.44.0"
-      }
-    },
-    "miniget": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-2.0.2.tgz",
-      "integrity": "sha512-rUYQiHXVjisRIuEdvIQxXPsAKp9Gltz5JdLWA8a3c/5265f2bZudg5mGtWcox0HHxkw51v8od/jLsqyYlM8UBw=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -561,19 +208,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -581,14 +215,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "*"
       }
     },
     "path-is-absolute": {
@@ -603,80 +229,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "prettier": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "resolve": {
       "version": "1.17.0",
@@ -686,21 +243,6 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
-    },
-    "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.7.1",
@@ -714,30 +256,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -745,15 +263,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
       }
     },
     "tslib": {
@@ -798,69 +307,17 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "ytdl-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.0.0.tgz",
-      "integrity": "sha512-609PreLRioAJ9SbRyWZuIRetD6IumTanm3WiJyB4rOCN4r6H/u82P8fSIl9h/3jkjUvK2licyXoz9CLW2cAkhw==",
-      "requires": {
-        "html-entities": "^1.3.1",
-        "m3u8stream": "^0.8.0",
-        "miniget": "^2.0.1",
-        "sax": "^1.1.3"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrape-youtube",
-  "version": "0.2.6",
-  "description": "A package to scrape youtube results for discord bots to use.",
+  "version": "1.0.4",
+  "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -11,8 +11,7 @@
     "prepublishOnly": "npm run lint",
     "preversion": "npm run lint",
     "version": "git add -A src",
-    "postversion": "git push && git push --tags",
-    "test": "ts-node examples/basic.ts"
+    "postversion": "git push && git push --tags"
   },
   "repository": {
     "type": "git",
@@ -34,16 +33,10 @@
   },
   "homepage": "https://github.com/DrKain/scrape-youtube#readme",
   "devDependencies": {
-    "@types/cheerio": "^0.22.18",
-    "@types/request": "^2.48.4",
     "prettier": "^2.0.5",
     "tslint": "^6.1.2",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.8.3"
   },
-  "dependencies": {
-    "cheerio": "^1.0.0-rc.3",
-    "request": "^2.88.2",
-    "ytdl-core": "^4.0.0"
-  }
+  "dependencies": {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,368 +1,111 @@
-import request = require('request');
-import cheerio = require('cheerio');
-import ytdl = require('ytdl-core');
+import { get } from 'https';
+import { ResultFilter, ResultType, SearchOptions, Video } from './interface';
+import { getVideoData } from './parser';
 
-export enum ResultType {
-    any = 'any',
-    video = 'video',
-    channel = 'channel',
-    playlist = 'playlist',
-    movie = 'movie',
-    live = 'live'
-}
-
-export const ResultFilter: { [key in ResultType]: string } = {
-    [ResultType.any]: 'CAA%253D',
-    [ResultType.video]: 'EgIQAQ%253D%253D',
-    [ResultType.channel]: 'EgIQAg%253D%253D',
-    [ResultType.playlist]: 'EgIQAw%253D%253D',
-    [ResultType.movie]: 'EgIQBA%253D%253D',
-    [ResultType.live]: 'EgJAAQ%253D%253D'
-};
-
-export interface SearchOptions {
-    query: string;
-    type: ResultType | string;
-    page: number;
-    limit: number;
-}
-
-export interface SearchResult {
-    type: ResultType;
-
-    channel: {
-        name: string;
-        link: string;
-        verified: boolean;
-    };
-
-    id: string;
-    title: string;
-    link: string;
-    description: string;
-    thumbnail: string;
-
-    duration?: number;
-    watching?: number;
-    views?: number;
-    uploaded?: string;
-    videoCount?: number;
-}
-
-export class Youtube {
-    public host = 'https://www.youtube.com';
-    public detectLinks = false;
-
+class Youtube {
     constructor() { }
 
-    /**
-     * Generates a request URL using the search options provided.
-     * @param params SearchOptions
-     */
-    private getRequestURL(params: SearchOptions): string {
-        return (
-            `${this.host}/results` +
-            this.querystring({
-                search_query: encodeURIComponent(params.query),
-                page: params.page,
-                sp: ResultFilter[params.type as ResultType]
-            })
-        );
+    private getURL(query: string, options: SearchOptions): string {
+        const url = new URL('/results', 'https://www.youtube.com');
+        url.search = new URLSearchParams({
+            search_query: query,
+            sp: ResultFilter[(options.type || 'video') as ResultType],
+            page: `${options.page ?? 0}`
+        }).toString();
+        return url.href;
     }
 
-    /**
-     * Converts an object into a browser query string.
-     * { one: 'two' } becomes ?one=two
-     * @param o Object
-     */
-    private querystring(o: any) {
-        return Object.keys(o).map((v, i) => (i !== 0 ? '&' : '?') + `${v}=${o[v]}`).join('');
-    }
-
-    /**
-     * Generate video thumbnail
-     * @param id Youtube video ID
-     */
-    private getThumbnail(id: any): string {
-        return `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
-    }
-
-    /**
-     * Convert an hh:mm:ss string into total seconds
-     * @param text hh:mm:ss string
-     */
-    private parseDuration(text: string): number {
-        const nums = text.split(':');
-        let sum = 0;
-        let multi = 1;
-
-        while (nums.length > 0) {
-            sum += multi * parseInt(nums.pop() || '-1', 10);
-            multi *= 60;
-        }
-
-        return sum;
-    }
-
-    /**
-     * Convert a string into a number.
-     * @param s string
-     */
-    private num(s: any): number {
-        return +`${s}`.replace(/[^0-9.]/g, '');
-    }
-
-    /**
-     * Compresses the "runs" texts into a single string.
-     * @param key vRender key
-     */
-    private compress(key: any) {
-        return (key && key['runs'] ?
-            key['runs'].map((v: any) => v.text) : []
-        ).join('');
-    }
-
-    /**
-     * Fetch channel badges and check if they are verified channels
-     * @param vRender vRender
-     */
-    private isChannelVerified(vRender: any) {
-        const badges = (vRender['ownerBadges'] ?
-            vRender['ownerBadges'].map((badge: any) => badge['metadataBadgeRenderer']['style']) : []
-        );
-        return badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST');
-    }
-
-    /**
-     * Extract channel data from the vRender object
-     * @param vRender vRender
-     */
-    private getChannelData(vRender: any): { name: string, link: string, verified: boolean } {
-        const channel: any = vRender['ownerText']['runs'][0];
-
-        return {
-            name: channel['text'],
-            link: (
-                'https://youtube.com' +
-                channel['navigationEndpoint']['commandMetadata']['webCommandMetadata']['url']
-            ),
-            verified: this.isChannelVerified(vRender)
-        };
-    }
-
-    private getDuration(vRender: any) {
-        return this.parseDuration(vRender['lengthText']['simpleText']);
-    }
-
-    private getViews(vRender: any) {
-        return this.num(vRender['viewCountText']['simpleText']);
-    }
-
-    private getUploadedDate(vRender: any) {
-        // Sometimes publishedTimeText is not available.
-        // EG: https://i.imgur.com/cR1na6k.png
-        return vRender['publishedTimeText'] ? vRender['publishedTimeText']['simpleText'] : '';
-    }
-
-    /**
-     * Load a url and begin scraping the data.
-     * @param url Youtube URL
-     * @param params SearchOptions
-     * @param options request.Options
-     */
-    private load(
-        url: string,
-        params: SearchOptions,
-        options?: request.Options
-    ): Promise<SearchResult[]> {
+    private extractRenderData(page: string): Promise<JSON> {
         return new Promise((resolve, reject) => {
-            request({ method: 'GET', url, ...(options || {}) }, async (err, res, body) => {
-                if (err) return reject(err);
-                try {
-                    const results: SearchResult[] = [];
-                    const $ = cheerio.load(body);
-                    const data: any[] = await this.extractInitialData($);
+            try {
+                // Last update they actually commented it as scraper data.
+                const data = page.split('// scraper_data_begin')[1].trim()
+                    .split('// scraper_data_end')[0].trim()
+                    .slice(0, -1)
+                    .slice('var ytInitialData = '.length);
 
-                    data.forEach((item: any) => {
-                        try {
-                            const vRender = item['videoRenderer'];
-                            if (vRender) {
-                                const id = vRender['videoId'];
+                resolve(
+                    JSON.parse(data).contents
+                        .twoColumnSearchResultsRenderer
+                        .primaryContents
+                        .sectionListRenderer
+                        .contents[0]
+                        .itemSectionRenderer
+                        .contents
+                );
+            } catch (e) {
+                console.log(e);
+                reject('Failed to extract video data. The request may have been blocked');
+            }
+        });
+    }
 
-                                // TODO: Add multiple types again
-                                const result: SearchResult = {
-                                    type: ResultType.video,
-                                    channel: this.getChannelData(vRender),
-                                    id,
-                                    title: this.compress(vRender['title']),
-                                    link: `https://www.youtube.com/watch?v=${id}`,
-                                    description: this.compress(vRender['descriptionSnippet']),
-                                    thumbnail: this.getThumbnail(id),
-                                    views: this.getViews(vRender),
-                                    duration: this.getDuration(vRender),
-                                    uploaded: this.getUploadedDate(vRender)
-                                };
+    /**
+     * Parse the data extracted from the page to match each interface
+     * @param data Video Renderer Data
+     */
+    private parseData(data: any): Promise<Video[]> {
+        return new Promise((resolve, reject) => {
+            try {
+                const results: Video[] = [];
 
-                                results.push(result);
-                            }
-                        } catch (e) {
-                            console.log(e);
-                        }
-                    });
+                data.forEach((item: any) => {
+                    const vRender = item['videoRenderer'];
+                    if (!vRender) return;
+
+                    try {
+                        const result: Video = getVideoData(vRender);
+                        results.push(result);
+                    } catch (e) {
+                        console.log(e);
+                    }
 
                     resolve(results);
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-    }
-
-    private extractInitialData($: any): Promise<any> {
-        return new Promise((resolve, reject) => {
-            try {
-                let json: any = null;
-
-                $('script').each((i: number, script: any) => {
-                    const html = $(script).html();
-
-                    if (html && html.includes('ytInitialData')) {
-                        const start = (html.split('var ytInitialData = ').pop() || '');
-                        const end = start.split('\n').shift();
-
-                        if (end) {
-                            json = JSON.parse(`${end.replace(/;/g, '')}`);
-
-                            // Unavoidable Ladder
-                            resolve(
-                                json.contents
-                                    .twoColumnSearchResultsRenderer
-                                    .primaryContents
-                                    .sectionListRenderer
-                                    .contents[0]
-                                    .itemSectionRenderer
-                                    .contents
-                            );
-                        } else throw Error('Failed to extract InitialData');
-                    }
                 });
-
-                if (!json) {
-                    throw Error('Failed to extract InitialData. The request may have been blocked.');
-                }
-
             } catch (e) {
-                reject(e);
+                console.warn(e);
+                reject('Fatal error when parsing result data. Please report this on GitHub');
             }
         });
     }
 
     /**
-     * Search youtube for results.
-     * Result type defaults to 'video'. See advanced use for more information
+     * Load the page and scrape the data
+     * @param query Search query
+     * @param options Search options
+     */
+    private load(query: string, options: SearchOptions): Promise<string> {
+        const url = this.getURL(query, options);
+
+        return new Promise((resolve, reject) => {
+            get(url, res => {
+                res.setEncoding('utf8');
+                let data = '';
+                res.on('data', chunk => data += chunk);
+                res.on('end', () => resolve(data));
+            }).on('error', reject);
+        });
+    }
+
+    /**
+     * Search YouTube for a list of videos
      * @param query Search Query
-     * @param options Search Options
-     * @param requestOptions request.Options
+     * @param options Optional Search Options
      */
-    public search(
-        query: string,
-        options?: Partial<SearchOptions>,
-        requestOptions?: request.Options
-    ): Promise<SearchResult[]> {
-        return new Promise(async (resolve, reject) => {
-
-            const params: SearchOptions = {
-                query: query.trim(),
-                page: 0,
-                type: ResultType.video,
-                limit: 10,
-                ...options,
-            };
-
-            if (params.query.length === 0) {
-                return reject(new Error('Search cannot be blank'));
-            }
-
-            if (params.type !== ResultType.video) {
-                params.type = ResultType.video;
-                console.warn('Search type must be `video`. Other types are unsupported in this version but will be re-added in the future');
-            }
-
-            if (!Object.keys(ResultType).includes(params.type)) {
-                return reject(new Error(`Unexpected result type: ${params.type}`));
-            }
-
-            if (params.page < 0) {
-                return reject(new Error(`Page number can not be lower than 0`));
-            }
-
-            if (params.limit <= 0) {
-                return reject(new Error('Limit can not be lower than 1'));
-            }
-
-            const url = this.getRequestURL(params);
-            this.load(url, params, requestOptions).then(resolve).catch(reject);
-        });
-    }
-
-    /**
-     * Fetches video information using the ytdl-core package, then generates a SearchResult
-     * @param query Youtube URL
-     */
-    private ytdlSearch(query: string): Promise<SearchResult> {
+    public search(query: string, options: SearchOptions = {}): Promise<Video[]> {
         return new Promise(async (resolve, reject) => {
             try {
-                const vdata = await ytdl.getInfo(query);
-                if (vdata && vdata.videoDetails) {
-                    const details = vdata.videoDetails;
-
-                    const preview: SearchResult = {
-                        type: ResultType.video,
-                        channel: {
-                            name: details.author.name,
-                            link: details.author.user_url,
-                            verified: details.author.verified
-                        },
-                        id: details.videoId,
-                        title: details.title,
-                        link: `https://www.youtube.com/watch?v=${details.videoId}`,
-                        description: details.shortDescription,
-                        thumbnail: this.getThumbnail(details.videoId),
-                        duration: +details.lengthSeconds,
-                        views: +details.viewCount
-                    };
-
-                    resolve(preview);
-                } else throw new Error('Failed to load video details');
+                const page = await this.load(query, options);
+                const data = await this.extractRenderData(page);
+                require('fs').writeFileSync('debug.json', JSON.stringify(data, null, 2));
+                const results = await this.parseData(data);
+                resolve(results);
             } catch (e) {
                 reject(e);
             }
-        });
-    }
-
-    /**
-     * Lazy shortcut to get the first result. Probably useful with discord bots.
-     * @param query Search String
-     * @param options request.Options
-     */
-    public searchOne(query: string, requestOptions?: request.Options): Promise<SearchResult | null> {
-        return new Promise(async (resolve, reject) => {
-
-            // Detect if input is already a video URL. This
-            // should save some time when it comes to discord
-            // bots
-            if (ytdl.validateURL(query)) {
-                this.ytdlSearch(query).then(resolve).catch(reject);
-            }  else {
-                this.search(query, { type: ResultType.video, limit: 1 }, requestOptions).then(results => {
-                    resolve(results.length ? results[0] : null);
-                }).catch(reject);
-            }
-
         });
     }
 }
 
-/* For quick use without creating a new instance */
 const youtube = new Youtube();
 export default youtube;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,56 @@
+export enum ResultType {
+    any = 'any',
+    video = 'video',
+    channel = 'channel',
+    playlist = 'playlist',
+    movie = 'movie',
+    live = 'live'
+}
+
+export interface SearchOptions {
+    type?: ResultType;
+    page?: number;
+}
+
+export const ResultFilter: { [key in ResultType]: string } = {
+    [ResultType.any]: 'CAA%253D',
+    [ResultType.video]: 'EgIQAQ%253D%253D',
+    [ResultType.channel]: 'EgIQAg%253D%253D',
+    [ResultType.playlist]: 'EgIQAw%253D%253D',
+    [ResultType.movie]: 'EgIQBA%253D%253D',
+    [ResultType.live]: 'EgJAAQ%253D%253D'
+};
+
+export interface Channel {
+    name: string;
+    link: string;
+    verified: boolean;
+    thumbnail: string;
+}
+
+export interface Result {
+    /** Video or Playlist ID */
+    id: string;
+    title: string;
+    link: string;
+    description: string;
+    thumbnail: string;
+    channel: Channel;
+}
+
+export interface LiveStream extends Result {
+    watching: number;
+}
+
+export interface Video extends Result {
+    views: number;
+    /** Sometimes the upload date is not available. YouTube is to blame, not this package. */
+    uploaded: string;
+    /** Duration in seconds */
+    duration: number;
+}
+
+export interface Playlist extends Result {
+    videoCount: number;
+    videos: Video[];
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,142 @@
+// This file contains all the functions used in extracting information from the video renderer objects
+import { Channel, Result, Video } from './interface';
+
+/**
+ * Fetch all badges the channel has
+ * @param video Video Renderer
+ */
+const getChannelBadges = (video: any) => {
+    const ownerBadges = video.ownerBadges;
+    return ownerBadges ? ownerBadges.map((badge: any) => badge['metadataBadgeRenderer']) : [];
+};
+
+/**
+ * Attempt to find out if the channel is verified
+ * @param video Video Renderer
+ */
+const isVerified = (video: any) => {
+    const badges = getChannelBadges(video);
+    return (
+        badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST') ||
+        badges.includes('BADGE_STYLE_TYPE_VERIFIED')
+    );
+};
+
+/**
+ * Attempt to fetch channel link
+ * @param channel Channel Renderer
+ */
+const getChannelLink = (channel: any) => {
+    return 'https://www.youtube.com' + (
+        channel.navigationEndpoint.browseEndpoint.canonicalBaseUrl ||
+        channel.navigationEndpoint.commandMetadata.webCommandMetadata.url
+    );
+};
+
+/**
+ * Compresses the "runs" texts into a single string.
+ * @param key Video Renderer key
+ */
+const compress = (key: any) => {
+    return (key && key['runs'] ? key['runs'].map((v: any) => v.text) : []).join('');
+};
+
+/**
+ * Parse an hh:mm:ss timestamp into total seconds
+ * @param text hh:mm:ss
+ */
+const parseDuration = (text: string): number => {
+    const nums = text.split(':');
+    let sum = 0;
+    let multi = 1;
+
+    while (nums.length > 0) {
+        sum += multi * parseInt(nums.pop() || '-1', 10);
+        multi *= 60;
+    }
+
+    return sum;
+};
+
+/**
+ * Sometimes the upload date is not available. YouTube is to blame, not this package.
+ * @param video Video Renderer
+ */
+const getUploadDate = (video: any) => {
+    return video.publishedTimeText ? video.publishedTimeText.simpleText : '';
+};
+
+const getViews = (video: any) => {
+    return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+};
+
+/**
+ * Attempt to fetch the channel thumbnail
+ * @param video Channel Renderer
+ */
+const getChannelThumbnail = (video: any) => {
+    return video.channelThumbnailSupportedRenderers
+        .channelThumbnailWithLinkRenderer
+        .thumbnail
+        .thumbnails[0].url;
+};
+
+const getVideoThumbnail = (id: string) => {
+    return `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
+};
+
+/**
+ * Fetch a video or playlist link using the supplied ID
+ * @param id ID
+ * @param playlist is playlist true/false
+ */
+const getLink = (id: string, playlist: false) => {
+    return (playlist ? 'https://www.youtube.com/playlist?list=' : 'https://youtu.be/') + id;
+};
+
+/**
+ * Fetch basic information about the channel
+ * @param video Video Renderer
+ */
+export const getChannelData = (video: any): Channel => {
+    const channel = video.ownerText.runs[0];
+    return {
+        name: channel.text,
+        link: getChannelLink(channel),
+        verified: isVerified(video),
+        thumbnail: getChannelThumbnail(video)
+    };
+};
+
+/**
+ * Fetch the default result data included in all result types
+ * @param result Video Renderer
+ */
+const getResultData = (result: any): Result => {
+    return {
+        id: result.videoId,
+        title: compress(result.title),
+        link: getLink(result.videoId, false),
+        description: compress(result.descriptionSnippet),
+        thumbnail: getVideoThumbnail(result.videoId),
+        channel: getChannelData(result)
+    };
+};
+
+/**
+ * Extract all information required for the "Video" result type
+ * @param result Video Renderer
+ */
+export const getVideoData = (result: any): Video => {
+    return {
+        ...getResultData(result),
+        views: getViews(result),
+        uploaded: getUploadDate(result),
+        duration: parseDuration(result.lengthText.simpleText)
+    };
+};
+
+// TODO: These ↓
+// const getPlaylistData = (result: any): Playlist => { };
+// const getSteamData = (result: any): LiveSteam => { };
+// const getMovieData = (result: any): Movie => { };


### PR DESCRIPTION
Everything has been rewritten from scratch.

- Substituted cheerio/request for https
    - Significantly faster with 20+ results fetched and parsed in half a second
- Fixed missing verified status on non-music channels #1   
- Added channel thumbnails  
- Reorganized interfaces and enumerations  
- Commented and optimized parser  
- Videos links now use the youtu.be domain  
- Removed ytdl-core that was added because of #13   
    - After some thought I decided this wasn't needed. It's easy enough to add in your bot.  
- Removed examples directory  
    - README makes this redundant 


