### PR TITLE
1.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-scrape-youtube
+Scrape YouTube
 =============
 
 [![NPM](https://img.shields.io/npm/v/scrape-youtube)](https://www.npmjs.com/package/scrape-youtube) [![NPM](https://img.shields.io/npm/dt/scrape-youtube)](https://www.npmjs.com/package/scrape-youtube) [![NPM](https://img.shields.io/npm/types/scrape-youtube)](https://www.npmjs.com/package/scrape-youtube)
   
- **What is this?***
+ **What is this?**
 ------------------
 A [lightning fast](https://i.imgur.com/ipsWhkv.png) package to scrape YouTube search results. This was made and optimized for Discord Bots. 
   
@@ -19,12 +19,21 @@ import youtube from 'scrape-youtube';
 #### Search  
 ```javascript
 youtube.search('Short Change Hero').then(results => {
-    console.log(results)
+    // Unless you specify a type, it will only return 'video' results
+    console.log(results.videos); 
 });
 ```
 
-#### Example Response
-This is the structure of a single result. The search function will return an array of up to 20 results.
+#### Custom Types
+Supported types are: `video`, `live`, `movie`, `any` and `playlist`
+```javascript
+youtube.search('lofi hip hop beats to relax/study to', { type: 'live' }).then(results => {
+  console.log(results.streams);
+})
+```
+
+#### Example Response (Video)
+This is the structure of a single video result. The search function will return up to 20 results per search.  
 ```json
 {
   "id": "lkvScx3Po8I",
@@ -42,9 +51,62 @@ This is the structure of a single result. The search function will return an arr
   "duration": 238,
   "uploaded": "6 years ago"
 }
-```  
+```
+
+#### Example Response (Live Stream)
+This is the structure of a single live stream result.
+```json
+{
+  "id": "5qap5aO4i9A",
+  "title": "lofi hip hop radio - beats to relax/study to",
+  "link": "https://youtu.be/5qap5aO4i9A",
+  "thumbnail": "https://i.ytimg.com/vi/5qap5aO4i9A/hqdefault.jpg",
+  "channel": {
+    "name": "ChilledCow",
+    "link": "https://www.youtube.com/channel/UCSJ4gkVC6NrvII8umztf0Ow",
+    "verified": false,
+    "thumbnail": "https://yt3.ggpht.com/a-/AOh14Gj1ME7zG6pJG6689WU13fYHmafnUGK7IMeWIg=s68-c-k-c0x00ffffff-no-rj-mo"
+  },
+  "watching": 34576
+}
+```
+
+### Example Response (Playlist)  
+This is the structure of a single playlist result. Please note that the "videos" will only contain 1-2 items. This is what is available from the search results. If you wish to load an entire playlist, consider using [ytdl-core](https://npmjs.com/package/ytdl-core).  
+```json 
+{
+  "id": "PLEPHBRITc9qNl4G4IaZPGsx0nueg6d_6N",
+  "title": "Johann Sebastian Bach Adagios for relaxation",
+  "link": "https://www.youtube.com/playlist?list=PLEPHBRITc9qNl4G4IaZPGsx0nueg6d_6N",
+  "thumbnail": "https://i.ytimg.com/vi/yoaNCEE4QLY/hqdefault.jpg",
+  "channel": {
+    "name": "Fredericia's Channel",
+    "link": "https://www.youtube.com/channel/UCUDT_zh1GA8qfisSZXemt6Q",
+    "verified": false,
+    "thumbnail": "https://www.gstatic.com/youtube/img/originals/promo/ytr-logo-for-search_160x160.png"
+  },
+  "videoCount": 15,
+  "videos": [
+    {
+      "id": "yoaNCEE4QLY",
+      "title": "J S Bach Jesu Joy of Man's Desiring chamber orchestra version",
+      "link": "https://youtu.be/yoaNCEE4QLY",
+      "duration": 211,
+      "thumbnail": "https://i.ytimg.com/vi/yoaNCEE4QLY/hqdefault.jpg"
+    },
+    {
+      "id": "mGV_oiAcmaY",
+      "title": "Bach Violin Concerto in D Minor",
+      "link": "https://youtu.be/mGV_oiAcmaY",
+      "duration": 381,
+      "thumbnail": "https://i.ytimg.com/vi/mGV_oiAcmaY/hqdefault.jpg"
+    }
+  ]
+}
+```
 
 #### Notes
-- Currently additional types like playlists, live streams and movies are unsupported. These will be re-added in some time.  
-- You can load another page by passing `{ page: 1 }` as the second parameter.
-
+1. You can load another page by passing `{ page: 1 }` as the second parameter.  
+2. Contributions are welcome and greatly appreciated.  
+3. If this package stops working please create an issue on GitHub so I can fix it as soon as possible.
+4. If this readme is lacking, Please feel free to create a PR fixing or adding any information you feel would help.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,6 @@
-import { SearchOptions, Video } from './interface';
+import { SearchOptions, Results } from './interface';
 declare class Youtube {
+    debug: boolean;
     constructor();
     private getURL;
     private extractRenderData;
@@ -14,12 +15,7 @@ declare class Youtube {
      * @param options Search options
      */
     private load;
-    /**
-     * Search YouTube for a list of videos
-     * @param query Search Query
-     * @param options Optional Search Options
-     */
-    search(query: string, options?: SearchOptions): Promise<Video[]>;
+    search(query: string, options?: SearchOptions): Promise<Results>;
 }
 declare const youtube: Youtube;
 export default youtube;

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,23 +36,20 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var https_1 = require("https");
 var interface_1 = require("./interface");
 var parser_1 = require("./parser");
+var https_1 = require("https");
 var Youtube = /** @class */ (function () {
     function Youtube() {
+        this.debug = false;
     }
     Youtube.prototype.getURL = function (query, options) {
-        var _a;
         var url = new URL('/results', 'https://www.youtube.com');
-        url.search = new URLSearchParams({
-            search_query: query,
-            sp: interface_1.ResultFilter[(options.type || 'video')],
-            page: "" + ((_a = options.page) !== null && _a !== void 0 ? _a : 0)
-        }).toString();
-        return url.href;
+        url.search = new URLSearchParams({ search_query: query }).toString();
+        return url.href + '&sp=' + interface_1.ResultFilter[(options.type || 'video')];
     };
     Youtube.prototype.extractRenderData = function (page) {
+        var _this = this;
         return new Promise(function (resolve, reject) {
             try {
                 // Last update they actually commented it as scraper data.
@@ -69,7 +66,8 @@ var Youtube = /** @class */ (function () {
                     .contents);
             }
             catch (e) {
-                console.log(e);
+                if (_this.debug)
+                    console.log(e);
                 reject('Failed to extract video data. The request may have been blocked');
             }
         });
@@ -79,22 +77,47 @@ var Youtube = /** @class */ (function () {
      * @param data Video Renderer Data
      */
     Youtube.prototype.parseData = function (data) {
+        var _this = this;
         return new Promise(function (resolve, reject) {
             try {
-                var results_1 = [];
+                var results_1 = {
+                    videos: [],
+                    playlists: [],
+                    streams: []
+                };
                 data.forEach(function (item) {
-                    var vRender = item['videoRenderer'];
-                    if (!vRender)
-                        return;
-                    try {
-                        var result = parser_1.getVideoData(vRender);
-                        results_1.push(result);
+                    if (item['videoRenderer'] && item['videoRenderer']['lengthText']) {
+                        try {
+                            var result = parser_1.getVideoData(item['videoRenderer']);
+                            results_1.videos.push(result);
+                        }
+                        catch (e) {
+                            if (_this.debug)
+                                console.log(e);
+                        }
                     }
-                    catch (e) {
-                        console.log(e);
+                    if (item['videoRenderer'] && !item['videoRenderer']['lengthText']) {
+                        try {
+                            var result = parser_1.getStreamData(item['videoRenderer']);
+                            results_1.streams.push(result);
+                        }
+                        catch (e) {
+                            if (_this.debug)
+                                console.log(e);
+                        }
                     }
-                    resolve(results_1);
+                    if (item['playlistRenderer']) {
+                        try {
+                            var result = parser_1.getPlaylistData(item['playlistRenderer']);
+                            results_1.playlists.push(result);
+                        }
+                        catch (e) {
+                            if (_this.debug)
+                                console.log(e);
+                        }
+                    }
                 });
+                resolve(results_1);
             }
             catch (e) {
                 console.warn(e);
@@ -109,6 +132,8 @@ var Youtube = /** @class */ (function () {
      */
     Youtube.prototype.load = function (query, options) {
         var url = this.getURL(query, options);
+        if (this.debug)
+            console.log(url);
         return new Promise(function (resolve, reject) {
             https_1.get(url, function (res) {
                 res.setEncoding('utf8');
@@ -118,11 +143,6 @@ var Youtube = /** @class */ (function () {
             }).on('error', reject);
         });
     };
-    /**
-     * Search YouTube for a list of videos
-     * @param query Search Query
-     * @param options Optional Search Options
-     */
     Youtube.prototype.search = function (query, options) {
         var _this = this;
         if (options === void 0) { options = {}; }
@@ -132,13 +152,12 @@ var Youtube = /** @class */ (function () {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 4, , 5]);
-                        return [4 /*yield*/, this.load(query, options)];
+                        return [4 /*yield*/, this.load(query, options || {})];
                     case 1:
                         page = _a.sent();
                         return [4 /*yield*/, this.extractRenderData(page)];
                     case 2:
                         data = _a.sent();
-                        require('fs').writeFileSync('debug.json', JSON.stringify(data, null, 2));
                         return [4 /*yield*/, this.parseData(data)];
                     case 3:
                         results = _a.sent();

--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -7,25 +7,39 @@ export declare enum ResultType {
     live = "live"
 }
 export interface SearchOptions {
-    type?: ResultType;
+    type?: ResultType | string;
     page?: number;
 }
 export declare const ResultFilter: {
     [key in ResultType]: string;
 };
+export interface Results {
+    videos: Video[];
+    playlists: Playlist[];
+    streams: LiveStream[];
+}
 export interface Channel {
     name: string;
     link: string;
     verified: boolean;
     thumbnail: string;
 }
-export interface Result {
-    /** Video or Playlist ID */
+export interface PlaylistVideo {
+    /** Playlist ID */
     id: string;
     title: string;
     link: string;
-    description: string;
+    duration: number;
+    /** Thumbnail of the first video in the playlist */
     thumbnail: string;
+}
+export interface Result {
+    /** Video ID */
+    id: string;
+    title: string;
+    link: string;
+    thumbnail: string;
+    /** Information about the uploader */
     channel: Channel;
 }
 export interface LiveStream extends Result {
@@ -37,8 +51,11 @@ export interface Video extends Result {
     uploaded: string;
     /** Duration in seconds */
     duration: number;
+    description: string;
 }
 export interface Playlist extends Result {
+    /** Number of videos in the playlist */
     videoCount: number;
-    videos: Video[];
+    /** This is not a list of all the videos, just the first two displayed in the search results */
+    videos: PlaylistVideo[];
 }

--- a/lib/parser.d.ts
+++ b/lib/parser.d.ts
@@ -1,4 +1,4 @@
-import { Channel, Video } from './interface';
+import { Channel, LiveStream, Playlist, Video } from './interface';
 /**
  * Fetch basic information about the channel
  * @param video Video Renderer
@@ -9,3 +9,9 @@ export declare const getChannelData: (video: any) => Channel;
  * @param result Video Renderer
  */
 export declare const getVideoData: (result: any) => Video;
+/**
+ * Extract all playlist information from the renderer
+ * @param result Playlist Renderer
+ */
+export declare const getPlaylistData: (result: any) => Playlist;
+export declare const getStreamData: (result: any) => LiveStream;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,16 +17,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 var getChannelBadges = function (video) {
     var ownerBadges = video.ownerBadges;
-    return ownerBadges ? ownerBadges.map(function (badge) { return badge['metadataBadgeRenderer']; }) : [];
+    return ownerBadges ? ownerBadges.map(function (badge) { return badge['metadataBadgeRenderer']['style']; }) : [];
 };
 /**
  * Attempt to find out if the channel is verified
  * @param video Video Renderer
  */
 var isVerified = function (video) {
+    var _a;
     var badges = getChannelBadges(video);
-    return (badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST') ||
-        badges.includes('BADGE_STYLE_TYPE_VERIFIED'));
+    return ((_a = badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST')) !== null && _a !== void 0 ? _a : badges.includes('BADGE_STYLE_TYPE_VERIFIED'));
 };
 /**
  * Attempt to fetch channel link
@@ -64,18 +64,45 @@ var parseDuration = function (text) {
 var getUploadDate = function (video) {
     return video.publishedTimeText ? video.publishedTimeText.simpleText : '';
 };
+/**
+ * Fetch the number of users watching a live stream
+ * @param result Video Renderer
+ */
+var getWatchers = function (result) {
+    try {
+        return +(result.viewCountText.runs[0].text.replace(/[^0-9]/g, ''));
+    }
+    catch (e) {
+        return 0;
+    }
+};
+/**
+ * Some paid movies do not have views
+ * @param video Video Renderer
+ */
 var getViews = function (video) {
-    return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+    try {
+        return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+    }
+    catch (e) {
+        return 0;
+    }
 };
 /**
  * Attempt to fetch the channel thumbnail
  * @param video Channel Renderer
  */
 var getChannelThumbnail = function (video) {
-    return video.channelThumbnailSupportedRenderers
-        .channelThumbnailWithLinkRenderer
-        .thumbnail
-        .thumbnails[0].url;
+    try {
+        return video.channelThumbnailSupportedRenderers
+            .channelThumbnailWithLinkRenderer
+            .thumbnail
+            .thumbnails[0].url;
+    }
+    catch (e) {
+        // Return a default youtube avatar when the channel thumbnail is not available (in playlists)
+        return "https://www.gstatic.com/youtube/img/originals/promo/ytr-logo-for-search_160x160.png";
+    }
 };
 var getVideoThumbnail = function (id) {
     return "https://i.ytimg.com/vi/" + id + "/hqdefault.jpg";
@@ -86,6 +113,7 @@ var getVideoThumbnail = function (id) {
  * @param playlist is playlist true/false
  */
 var getLink = function (id, playlist) {
+    if (playlist === void 0) { playlist = false; }
     return (playlist ? 'https://www.youtube.com/playlist?list=' : 'https://youtu.be/') + id;
 };
 /**
@@ -93,12 +121,33 @@ var getLink = function (id, playlist) {
  * @param video Video Renderer
  */
 exports.getChannelData = function (video) {
-    var channel = video.ownerText.runs[0];
+    var channel = (video.ownerText || video.longBylineText)['runs'][0];
     return {
         name: channel.text,
         link: getChannelLink(channel),
         verified: isVerified(video),
         thumbnail: getChannelThumbnail(video)
+    };
+};
+/**
+ * Get the playlist thumbnail (the first video in the list)
+ * @param result Playlist Renderer
+ */
+var getPlaylistThumbnail = function (result) {
+    return getVideoThumbnail(result.navigationEndpoint.watchEndpoint.videoId);
+};
+/**
+ * Similar to getResultData, but with minor changes for playlists
+ * @param result Playlist Renderer
+ */
+var getPlaylistResultData = function (result) {
+    var id = result.playlistId;
+    return {
+        id: id,
+        title: result.title.simpleText,
+        link: getLink(id, true),
+        thumbnail: getPlaylistThumbnail(result),
+        channel: exports.getChannelData(result)
     };
 };
 /**
@@ -110,9 +159,21 @@ var getResultData = function (result) {
         id: result.videoId,
         title: compress(result.title),
         link: getLink(result.videoId, false),
-        description: compress(result.descriptionSnippet),
         thumbnail: getVideoThumbnail(result.videoId),
         channel: exports.getChannelData(result)
+    };
+};
+/**
+ * Extract information about a video in a playlist
+ * @param child Child Renderer
+ */
+var getPlaylistVideo = function (child) {
+    return {
+        id: child.videoId,
+        title: child.title.simpleText,
+        link: getLink(child.videoId),
+        duration: parseDuration(child.lengthText.simpleText),
+        thumbnail: getVideoThumbnail(child.videoId)
     };
 };
 /**
@@ -120,9 +181,23 @@ var getResultData = function (result) {
  * @param result Video Renderer
  */
 exports.getVideoData = function (result) {
-    return __assign(__assign({}, getResultData(result)), { views: getViews(result), uploaded: getUploadDate(result), duration: parseDuration(result.lengthText.simpleText) });
+    return __assign(__assign({}, getResultData(result)), { description: compress(result.descriptionSnippet), views: getViews(result), uploaded: getUploadDate(result), duration: result.lengthText ? parseDuration(result.lengthText.simpleText) : 0 });
 };
-// TODO: These ↓
-// const getPlaylistData = (result: any): Playlist => { };
-// const getSteamData = (result: any): LiveSteam => { };
-// const getMovieData = (result: any): Movie => { };
+/**
+ * Extract all playlist information from the renderer
+ * @param result Playlist Renderer
+ */
+exports.getPlaylistData = function (result) {
+    var cvideos = [];
+    // Loop through any visible child videos and extract the data
+    result.videos.map(function (video) {
+        try {
+            cvideos.push(getPlaylistVideo(video['childVideoRenderer']));
+        }
+        catch (e) { }
+    });
+    return __assign(__assign({}, getPlaylistResultData(result)), { videoCount: +result['videoCount'], videos: cvideos });
+};
+exports.getStreamData = function (result) {
+    return __assign(__assign({}, getResultData(result)), { watching: getWatchers(result) });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrape-youtube",
-  "version": "1.1.0",
+  "version": "1.0.6",
   "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrape-youtube",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,15 @@
+import { ResultFilter, ResultType, SearchOptions, Video, Playlist, Results, LiveStream } from './interface';
+import { getStreamData, getPlaylistData, getVideoData } from './parser';
 import { get } from 'https';
-import { ResultFilter, ResultType, SearchOptions, Video } from './interface';
-import { getVideoData } from './parser';
 
 class Youtube {
+    public debug = false;
     constructor() { }
 
     private getURL(query: string, options: SearchOptions): string {
         const url = new URL('/results', 'https://www.youtube.com');
-        url.search = new URLSearchParams({
-            search_query: query,
-            sp: ResultFilter[(options.type || 'video') as ResultType],
-            page: `${options.page ?? 0}`
-        }).toString();
-        return url.href;
+        url.search = new URLSearchParams({ search_query: query }).toString();
+        return url.href + '&sp=' + ResultFilter[(options.type || 'video') as ResultType];
     }
 
     private extractRenderData(page: string): Promise<JSON> {
@@ -34,7 +31,7 @@ class Youtube {
                         .contents
                 );
             } catch (e) {
-                console.log(e);
+                if (this.debug) console.log(e);
                 reject('Failed to extract video data. The request may have been blocked');
             }
         });
@@ -44,24 +41,48 @@ class Youtube {
      * Parse the data extracted from the page to match each interface
      * @param data Video Renderer Data
      */
-    private parseData(data: any): Promise<Video[]> {
+    private parseData(data: any): Promise<Results> {
         return new Promise((resolve, reject) => {
             try {
-                const results: Video[] = [];
+                const results: Results = {
+                    videos: [],
+                    playlists: [],
+                    streams: []
+                };
 
                 data.forEach((item: any) => {
-                    const vRender = item['videoRenderer'];
-                    if (!vRender) return;
 
-                    try {
-                        const result: Video = getVideoData(vRender);
-                        results.push(result);
-                    } catch (e) {
-                        console.log(e);
+                    if (item['videoRenderer'] && item['videoRenderer']['lengthText']) {
+                        try {
+                            const result: Video = getVideoData(item['videoRenderer']);
+                            results.videos.push(result);
+                        } catch (e) {
+                            if (this.debug) console.log(e);
+                        }
                     }
 
-                    resolve(results);
+
+                    if (item['videoRenderer'] && !item['videoRenderer']['lengthText']) {
+                        try {
+                            const result: LiveStream = getStreamData(item['videoRenderer']);
+                            results.streams.push(result);
+                        } catch (e) {
+                            if (this.debug) console.log(e);
+                        }
+                    }
+
+
+                    if (item['playlistRenderer']) {
+                        try {
+                            const result: Playlist = getPlaylistData(item['playlistRenderer']);
+                            results.playlists.push(result);
+                        } catch (e) {
+                            if (this.debug) console.log(e);
+                        }
+                    }
                 });
+
+                resolve(results);
             } catch (e) {
                 console.warn(e);
                 reject('Fatal error when parsing result data. Please report this on GitHub');
@@ -76,6 +97,7 @@ class Youtube {
      */
     private load(query: string, options: SearchOptions): Promise<string> {
         const url = this.getURL(query, options);
+        if (this.debug) console.log(url);
 
         return new Promise((resolve, reject) => {
             get(url, res => {
@@ -87,17 +109,11 @@ class Youtube {
         });
     }
 
-    /**
-     * Search YouTube for a list of videos
-     * @param query Search Query
-     * @param options Optional Search Options
-     */
-    public search(query: string, options: SearchOptions = {}): Promise<Video[]> {
+    public search(query: string, options: SearchOptions = {}): Promise<Results> {
         return new Promise(async (resolve, reject) => {
             try {
-                const page = await this.load(query, options);
+                const page = await this.load(query, options || {});
                 const data = await this.extractRenderData(page);
-                require('fs').writeFileSync('debug.json', JSON.stringify(data, null, 2));
                 const results = await this.parseData(data);
                 resolve(results);
             } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ class Youtube {
                         }
                     }
 
-
                     if (item['videoRenderer'] && !item['videoRenderer']['lengthText']) {
                         try {
                             const result: LiveStream = getStreamData(item['videoRenderer']);
@@ -70,7 +69,6 @@ class Youtube {
                             if (this.debug) console.log(e);
                         }
                     }
-
 
                     if (item['playlistRenderer']) {
                         try {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -8,7 +8,7 @@ export enum ResultType {
 }
 
 export interface SearchOptions {
-    type?: ResultType;
+    type?: ResultType | string;
     page?: number;
 }
 
@@ -21,6 +21,12 @@ export const ResultFilter: { [key in ResultType]: string } = {
     [ResultType.live]: 'EgJAAQ%253D%253D'
 };
 
+export interface Results {
+    videos: Video[];
+    playlists: Playlist[];
+    streams: LiveStream[];
+}
+
 export interface Channel {
     name: string;
     link: string;
@@ -28,13 +34,23 @@ export interface Channel {
     thumbnail: string;
 }
 
-export interface Result {
-    /** Video or Playlist ID */
+export interface PlaylistVideo {
+    /** Playlist ID */
     id: string;
     title: string;
     link: string;
-    description: string;
+    duration: number;
+    /** Thumbnail of the first video in the playlist */
     thumbnail: string;
+}
+
+export interface Result {
+    /** Video ID */
+    id: string;
+    title: string;
+    link: string;
+    thumbnail: string;
+    /** Information about the uploader */
     channel: Channel;
 }
 
@@ -48,9 +64,12 @@ export interface Video extends Result {
     uploaded: string;
     /** Duration in seconds */
     duration: number;
+    description: string;
 }
 
 export interface Playlist extends Result {
+    /** Number of videos in the playlist */
     videoCount: number;
-    videos: Video[];
+    /** This is not a list of all the videos, just the first two displayed in the search results */
+    videos: PlaylistVideo[];
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 // This file contains all the functions used in extracting information from the video renderer objects
-import { Channel, Result, Video } from './interface';
+import { Channel, LiveStream, Playlist, PlaylistVideo, Result, Video } from './interface';
 
 /**
  * Fetch all badges the channel has
@@ -7,7 +7,7 @@ import { Channel, Result, Video } from './interface';
  */
 const getChannelBadges = (video: any) => {
     const ownerBadges = video.ownerBadges;
-    return ownerBadges ? ownerBadges.map((badge: any) => badge['metadataBadgeRenderer']) : [];
+    return ownerBadges ? ownerBadges.map((badge: any) => badge['metadataBadgeRenderer']['style']) : [];
 };
 
 /**
@@ -17,7 +17,7 @@ const getChannelBadges = (video: any) => {
 const isVerified = (video: any) => {
     const badges = getChannelBadges(video);
     return (
-        badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST') ||
+        badges.includes('BADGE_STYLE_TYPE_VERIFIED_ARTIST') ??
         badges.includes('BADGE_STYLE_TYPE_VERIFIED')
     );
 };
@@ -66,8 +66,28 @@ const getUploadDate = (video: any) => {
     return video.publishedTimeText ? video.publishedTimeText.simpleText : '';
 };
 
+/**
+ * Fetch the number of users watching a live stream
+ * @param result Video Renderer
+ */
+const getWatchers = (result: any) => {
+    try {
+        return +(result.viewCountText.runs[0].text.replace(/[^0-9]/g, ''));
+    } catch (e) {
+        return 0;
+    }
+};
+
+/**
+ * Some paid movies do not have views
+ * @param video Video Renderer
+ */
 const getViews = (video: any) => {
-    return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+    try {
+        return +(video.viewCountText.simpleText.replace(/[^0-9]/g, ''));
+    } catch (e) {
+        return 0;
+    }
 };
 
 /**
@@ -75,10 +95,15 @@ const getViews = (video: any) => {
  * @param video Channel Renderer
  */
 const getChannelThumbnail = (video: any) => {
-    return video.channelThumbnailSupportedRenderers
-        .channelThumbnailWithLinkRenderer
-        .thumbnail
-        .thumbnails[0].url;
+    try {
+        return video.channelThumbnailSupportedRenderers
+            .channelThumbnailWithLinkRenderer
+            .thumbnail
+            .thumbnails[0].url;
+    } catch (e) {
+        // Return a default youtube avatar when the channel thumbnail is not available (in playlists)
+        return `https://www.gstatic.com/youtube/img/originals/promo/ytr-logo-for-search_160x160.png`;
+    }
 };
 
 const getVideoThumbnail = (id: string) => {
@@ -90,7 +115,7 @@ const getVideoThumbnail = (id: string) => {
  * @param id ID
  * @param playlist is playlist true/false
  */
-const getLink = (id: string, playlist: false) => {
+const getLink = (id: string, playlist = false) => {
     return (playlist ? 'https://www.youtube.com/playlist?list=' : 'https://youtu.be/') + id;
 };
 
@@ -99,12 +124,36 @@ const getLink = (id: string, playlist: false) => {
  * @param video Video Renderer
  */
 export const getChannelData = (video: any): Channel => {
-    const channel = video.ownerText.runs[0];
+    const channel = (video.ownerText || video.longBylineText)['runs'][0];
     return {
         name: channel.text,
         link: getChannelLink(channel),
         verified: isVerified(video),
         thumbnail: getChannelThumbnail(video)
+    };
+};
+
+/**
+ * Get the playlist thumbnail (the first video in the list)
+ * @param result Playlist Renderer
+ */
+const getPlaylistThumbnail = (result: any) => {
+    return getVideoThumbnail(result.navigationEndpoint.watchEndpoint.videoId);
+};
+
+/**
+ * Similar to getResultData, but with minor changes for playlists
+ * @param result Playlist Renderer
+ */
+const getPlaylistResultData = (result: any): Result => {
+    const id = result.playlistId;
+
+    return {
+        id,
+        title: result.title.simpleText,
+        link: getLink(id, true),
+        thumbnail: getPlaylistThumbnail(result),
+        channel: getChannelData(result)
     };
 };
 
@@ -117,9 +166,22 @@ const getResultData = (result: any): Result => {
         id: result.videoId,
         title: compress(result.title),
         link: getLink(result.videoId, false),
-        description: compress(result.descriptionSnippet),
         thumbnail: getVideoThumbnail(result.videoId),
         channel: getChannelData(result)
+    };
+};
+
+/**
+ * Extract information about a video in a playlist
+ * @param child Child Renderer
+ */
+const getPlaylistVideo = (child: any): PlaylistVideo => {
+    return {
+        id: child.videoId,
+        title: child.title.simpleText,
+        link: getLink(child.videoId),
+        duration: parseDuration(child.lengthText.simpleText),
+        thumbnail: getVideoThumbnail(child.videoId)
     };
 };
 
@@ -130,13 +192,37 @@ const getResultData = (result: any): Result => {
 export const getVideoData = (result: any): Video => {
     return {
         ...getResultData(result),
+        description: compress(result.descriptionSnippet),
         views: getViews(result),
         uploaded: getUploadDate(result),
-        duration: parseDuration(result.lengthText.simpleText)
+        duration: result.lengthText ? parseDuration(result.lengthText.simpleText) : 0
     };
 };
 
-// TODO: These ↓
-// const getPlaylistData = (result: any): Playlist => { };
-// const getSteamData = (result: any): LiveSteam => { };
-// const getMovieData = (result: any): Movie => { };
+/**
+ * Extract all playlist information from the renderer
+ * @param result Playlist Renderer
+ */
+export const getPlaylistData = (result: any): Playlist => {
+    const cvideos: any = [];
+
+    // Loop through any visible child videos and extract the data
+    result.videos.map((video: any) => {
+        try {
+            cvideos.push(getPlaylistVideo(video['childVideoRenderer']));
+        } catch (e) { }
+    });
+
+    return {
+        ...getPlaylistResultData(result),
+        videoCount: +result['videoCount'],
+        videos: cvideos
+    };
+};
+
+export const getStreamData = (result: any): LiveStream => {
+    return {
+        ...getResultData(result),
+        watching: getWatchers(result)
+    };
+};


### PR DESCRIPTION
This will complete and close #11 

- Added an option to debugging `youtube.debug = true`
- Added support for movies, playlists and live streams!
- Modify results data
- Fix invalid types in url creation  
- Updated README to include more examples  
  
Search results will now return the following object regardless of what type is specified:  
```json
{
    "videos": [],
    "streams": [],
    "playlists": []
}
```  
I did this to avoid function overloading and to better support: `{ type: 'all' }`. It will also help with intellisense for those of you who appreciate that kind of thing.    
Movies are considered videos as they are almost identical, However in some cases of paid movies the `views` count will be unavailable (defaults to 0)