### PR TITLE
2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Scrape YouTube
   
  **What is this?**
 ------------------
-A [lightning fast](https://i.imgur.com/ipsWhkv.png) package to scrape YouTube search results. This was made and optimized for Discord Bots. 
+A [lightning fast](https://i.imgur.com/ipsWhkv.png) package to scrape YouTube search results. This was made and optimized for Discord Bots.   
+This package is updated often to fix minor problems or parsing issues. Please ensure you have the latest version before making an issue on GitHub.  
   
 #### Install  
 ```npm install scrape-youtube```
@@ -105,8 +106,24 @@ This is the structure of a single playlist result. Please note that the "videos"
 }
 ```
 
+### Custom Filters  
+You can pass `{ sp: 'ABC' }` as the second parameter to use custom filters like upload date, duration, features ect.  
+You will need to fetch the SP parameter yourself from youtube. Please see [this image](https://i.imgur.com/9WHMvkI.png) for an example.  
+
+### Custom Request Options
+You can pass `{ requestOptions: { } }` as the second parameter to use custom headers, agents ect.  
+See [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback) for more information.
+Example:  
+```javascript  
+youtube.search('Poets of the fall', {
+    requestOptions: {
+        headers: { 'Accept-Language': 'de' }
+    }
+})
+```
+
 #### Notes
-1. You can load another page by passing `{ page: 1 }` as the second parameter.  
-2. Contributions are welcome and greatly appreciated.  
-3. If this package stops working please create an issue on GitHub so I can fix it as soon as possible.
-4. If this readme is lacking, Please feel free to create a PR fixing or adding any information you feel would help.
+
+- Multiple pages can not be loaded. YouTube changed how loading works so this is currently not available.  
+- If this package stops working please create an issue on GitHub so I can fix it as soon as possible.
+- If this readme is lacking, Please feel free to create a PR fixing or adding any information you feel would help. I gladly accept any helpful pull requests or contributions.

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,13 @@ var Youtube = /** @class */ (function () {
     }
     Youtube.prototype.getURL = function (query, options) {
         var url = new URL('/results', 'https://www.youtube.com');
-        url.search = new URLSearchParams({ search_query: encodeURIComponent(query) }).toString();
-        return url.href + '&sp=' + interface_1.ResultFilter[(options.type || 'video')];
+        var sp = interface_1.ResultFilter[(options.type || 'video')];
+        url.search = new URLSearchParams({
+            search_query: query
+        }).toString();
+        if (options.sp)
+            sp = options.sp;
+        return url.href + '&sp=' + sp;
     };
     Youtube.prototype.extractRenderData = function (page) {
         var _this = this;
@@ -131,7 +136,7 @@ var Youtube = /** @class */ (function () {
         if (this.debug)
             console.log(url);
         return new Promise(function (resolve, reject) {
-            https_1.get(url, function (res) {
+            https_1.get(url, (options.requestOptions || {}), function (res) {
                 res.setEncoding('utf8');
                 var data = '';
                 res.on('data', function (chunk) { return data += chunk; });

--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+import { RequestOptions } from 'https';
 export declare enum ResultType {
     any = "any",
     video = "video",
@@ -8,7 +10,14 @@ export declare enum ResultType {
 }
 export interface SearchOptions {
     type?: ResultType | string;
-    page?: number;
+    /**
+     * Filter override. See README for more information.
+     */
+    sp?: string;
+    /**
+     * https://nodejs.org/api/http.html#http_http_request_options_callback
+     */
+    requestOptions?: RequestOptions;
 }
 export declare const ResultFilter: {
     [key in ResultType]: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scrape-youtube",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,15 @@ class Youtube {
 
     private getURL(query: string, options: SearchOptions): string {
         const url = new URL('/results', 'https://www.youtube.com');
-        url.search = new URLSearchParams({ search_query: encodeURIComponent(query) }).toString();
-        return url.href + '&sp=' + ResultFilter[(options.type || 'video') as ResultType];
+        let sp = ResultFilter[(options.type || 'video') as ResultType];
+
+        url.search = new URLSearchParams({
+            search_query: query
+        }).toString();
+
+        if (options.sp) sp = options.sp;
+
+        return url.href + '&sp=' + sp;
     }
 
     private extractRenderData(page: string): Promise<JSON> {
@@ -93,7 +100,7 @@ class Youtube {
         if (this.debug) console.log(url);
 
         return new Promise((resolve, reject) => {
-            get(url, res => {
+            get(url, (options.requestOptions || {}), res => {
                 res.setEncoding('utf8');
                 let data = '';
                 res.on('data', chunk => data += chunk);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,3 +1,5 @@
+import { RequestOptions } from 'https';
+
 export enum ResultType {
     any = 'any',
     video = 'video',
@@ -9,7 +11,15 @@ export enum ResultType {
 
 export interface SearchOptions {
     type?: ResultType | string;
-    page?: number;
+    /**
+     * Filter override. See README for more information.
+     */
+    sp?: string;
+    /**
+     * https://nodejs.org/api/http.html#http_http_request_options_callback
+     */
+    requestOptions?: RequestOptions;
+
 }
 
 export const ResultFilter: { [key in ResultType]: string } = {


### PR DESCRIPTION
- Removed: `page` option. YouTube has removed this functionality from the search.  
I'll see if I can find another way around this eventually.  
- Added: Custom http request options  
- Added: SP override. See README.  
- Fixed: Bad encoding in query parameters  
 
See README for more information