### PR TITLE
Add support for richGridRenderer

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,8 @@
 import { SearchOptions, Results } from './interface';
 declare class Youtube {
+    /**
+     * Enable debugging for extra information during each search
+     */
     debug: boolean;
     constructor();
     private getURL;

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,9 @@ var parser_1 = require("./parser");
 var https_1 = require("https");
 var Youtube = /** @class */ (function () {
     function Youtube() {
+        /**
+         * Enable debugging for extra information during each search
+         */
         this.debug = false;
     }
     Youtube.prototype.getURL = function (query, options) {
@@ -59,17 +62,31 @@ var Youtube = /** @class */ (function () {
             try {
                 var data = page.split('var ytInitialData = ')[1]
                     .split(';</script>')[0];
-                var videoRenderer = JSON.parse(data).contents
+                var render = null;
+                var contents = [];
+                var primary = JSON.parse(data).contents
                     .twoColumnSearchResultsRenderer
-                    .primaryContents
-                    .sectionListRenderer
-                    .contents.filter(function (item) { return item.itemSectionRenderer; }).shift();
-                resolve(videoRenderer.itemSectionRenderer.contents);
+                    .primaryContents;
+                // The renderer we want. This should contain all search result information
+                if (primary['sectionListRenderer']) {
+                    if (_this.debug)
+                        console.log('[ytInitialData] sectionListRenderer');
+                    render = primary.sectionListRenderer.contents.filter(function (item) { return item.itemSectionRenderer; }).shift();
+                    contents = render.itemSectionRenderer.contents;
+                }
+                // YouTube occasionally switches to a rich grid renderer.
+                // More testing will be needed to see how different this is from sectionListRenderer
+                if (primary['richGridRenderer']) {
+                    if (_this.debug)
+                        console.log('[ytInitialData] richGridRenderer');
+                    contents = primary.richGridRenderer.contents.filter(function (item) {
+                        return item.richItemRenderer && item.richItemRenderer.content;
+                    }).map(function (item) { return item.richItemRenderer.content; });
+                }
+                resolve(contents);
             }
             catch (e) {
-                if (_this.debug)
-                    console.log(e);
-                reject('Failed to extract video data. Please report this issue on GitHub so it can be fixed.');
+                reject(e);
             }
         });
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scrape-youtube",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
Discovered in #29 YouTube seemingly randomly switches to a `richGridRenderer` instead of `sectionListRenderer`. It should be compatible with the current parser, but if you come across any issues please open an issue.  
  
