### PR TITLE
Advanced debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ youtube.search('Poets of the fall', {
 })
 ```
 
+### Debugging  
+
+In some cases advanced debugging might be required for fixing issues on GitHub.   
+When enabled **each search** will create 3 files, please compress/zip and include with your issue.  
+**It's not recommended to use this unless requested specifically.**  
+  
+```javascript  
+youtube.debug = true; // Enable regular debugging
+youtube.debugger.enabled = true; // Enable debug dumps
+youtube.debugger.setDirectory('path/to/somewhere'); // Directory to write the dumps  
+``` 
+
 #### Notes
 
 - Multiple pages can not be loaded. YouTube changed how loading works so this is currently not available.  

--- a/lib/debugdump.d.ts
+++ b/lib/debugdump.d.ts
@@ -1,0 +1,21 @@
+/**
+ * This is used to dump search information to a file. This is not used by default
+ */
+export declare class DebugDumper {
+    enabled: boolean;
+    private dir;
+    constructor();
+    /**
+     * Set the directory to dump debug files into. You can zip this directory and include it
+     * in your GitHub issue.
+     * @param dir Any existing directory
+     */
+    setDirectory(dir: string): void;
+    /**
+     * Dump some information to the debug dump directory.
+     * @param id ID of the data dump
+     * @param key Type of data being dumped
+     * @param _data Raw data to write
+     */
+    dump(id: string, key: string, _data: any): void;
+}

--- a/lib/debugdump.js
+++ b/lib/debugdump.js
@@ -1,0 +1,61 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var fs_1 = require("fs");
+var path_1 = require("path");
+/**
+ * This is used to dump search information to a file. This is not used by default
+ */
+var DebugDumper = /** @class */ (function () {
+    function DebugDumper() {
+        this.enabled = false;
+        this.dir = '';
+    }
+    /**
+     * Set the directory to dump debug files into. You can zip this directory and include it
+     * in your GitHub issue.
+     * @param dir Any existing directory
+     */
+    DebugDumper.prototype.setDirectory = function (dir) {
+        if (!fs_1.existsSync(dir)) {
+            throw Error('[Debugger] Dump directory does not exist. Please create it');
+        }
+        this.dir = dir;
+    };
+    /**
+     * Dump some information to the debug dump directory.
+     * @param id ID of the data dump
+     * @param key Type of data being dumped
+     * @param _data Raw data to write
+     */
+    DebugDumper.prototype.dump = function (id, key, _data) {
+        if (!this.enabled)
+            return;
+        if (this.dir === '') {
+            throw Error('[Debugger] Directory not set. Use youtube.debugger.setDirectory()');
+        }
+        var file = null;
+        var data = null;
+        switch (key) {
+            case 'opts':
+                file = path_1.join(this.dir, id + '-opts.json');
+                data = JSON.stringify(_data, null, 2);
+                break;
+            case 'page':
+                file = path_1.join(this.dir, id + '-page.html');
+                data = _data;
+                break;
+            case 'vids':
+                file = path_1.join(this.dir, id + '-vids.json');
+                data = JSON.stringify(_data, null, 2);
+                break;
+        }
+        if (file && data) {
+            fs_1.writeFileSync(file, data);
+            console.log("[Debugger] Wrote data to " + file);
+        }
+        else
+            console.log('[Debugger] Failed to prepare file or data');
+    };
+    return DebugDumper;
+}());
+exports.DebugDumper = DebugDumper;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,9 +1,11 @@
 import { SearchOptions, Results } from './interface';
+import { DebugDumper } from './debugdump';
 declare class Youtube {
     /**
      * Enable debugging for extra information during each search
      */
     debug: boolean;
+    debugger: DebugDumper;
     constructor();
     private getURL;
     private extractRenderData;
@@ -18,6 +20,7 @@ declare class Youtube {
      * @param options Search options
      */
     private load;
+    private getDebugID;
     search(query: string, options?: SearchOptions): Promise<Results>;
 }
 declare const youtube: Youtube;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -39,12 +50,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var interface_1 = require("./interface");
 var parser_1 = require("./parser");
 var https_1 = require("https");
+var debugdump_1 = require("./debugdump");
 var Youtube = /** @class */ (function () {
     function Youtube() {
         /**
          * Enable debugging for extra information during each search
          */
         this.debug = false;
+        this.debugger = new debugdump_1.DebugDumper();
     }
     Youtube.prototype.getURL = function (query, options) {
         var url = new URL('/results', 'https://www.youtube.com');
@@ -167,6 +180,9 @@ var Youtube = /** @class */ (function () {
             }).on('error', reject);
         });
     };
+    Youtube.prototype.getDebugID = function () {
+        return ("" + Math.random()).replace('.', '');
+    };
     Youtube.prototype.search = function (query, options) {
         var _this = this;
         if (options === void 0) { options = {}; }
@@ -176,7 +192,8 @@ var Youtube = /** @class */ (function () {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 4, , 5]);
-                        return [4 /*yield*/, this.load(query, options || {})];
+                        options = __assign(__assign({}, options), { _debugid: this.getDebugID() });
+                        return [4 /*yield*/, this.load(query, options)];
                     case 1:
                         page = _a.sent();
                         return [4 /*yield*/, this.extractRenderData(page)];
@@ -185,6 +202,15 @@ var Youtube = /** @class */ (function () {
                         return [4 /*yield*/, this.parseData(data)];
                     case 3:
                         results = _a.sent();
+                        /**
+                         * This will create 3 files in the debugger directory.
+                         * It's not recommended to leave this enabled. Only when asked by DrKain via GitHub
+                         */
+                        if (this.debug && this.debugger.enabled && options._debugid) {
+                            this.debugger.dump(options._debugid, 'vids', results);
+                            this.debugger.dump(options._debugid, 'opts', __assign({ query: query }, options));
+                            this.debugger.dump(options._debugid, 'page', page);
+                        }
                         resolve(results);
                         return [3 /*break*/, 5];
                     case 4:

--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -8,6 +8,12 @@ export declare enum ResultType {
     movie = "movie",
     live = "live"
 }
+export interface DebugData {
+    options?: SearchOptions;
+    results?: Results;
+    page?: string;
+    timestamp?: string;
+}
 export interface SearchOptions {
     type?: ResultType | string;
     /**
@@ -18,6 +24,8 @@ export interface SearchOptions {
      * https://nodejs.org/api/http.html#http_http_request_options_callback
      */
     requestOptions?: RequestOptions;
+    /** ID used when debugging. Do not change */
+    _debugid?: string;
 }
 export declare const ResultFilter: {
     [key in ResultType]: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scrape-youtube",
-    "version": "2.0.9",
+    "version": "2.1.0",
     "description": "A lightning fast package to scrape YouTube search results. This was made for Discord Bots.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/debugdump.ts
+++ b/src/debugdump.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * This is used to dump search information to a file. This is not used by default
+ */
+export class DebugDumper {
+    public enabled = false;
+    private dir = '';
+
+    constructor() { }
+
+    /**
+     * Set the directory to dump debug files into. You can zip this directory and include it
+     * in your GitHub issue.
+     * @param dir Any existing directory
+     */
+    public setDirectory(dir: string) {
+        if (!existsSync(dir)) {
+            throw Error('[Debugger] Dump directory does not exist. Please create it');
+        }
+        this.dir = dir;
+    }
+
+    /**
+     * Dump some information to the debug dump directory.
+     * @param id ID of the data dump
+     * @param key Type of data being dumped
+     * @param _data Raw data to write
+     */
+    public dump(id: string, key: string, _data: any) {
+        if (!this.enabled) return;
+
+        if (this.dir === '') {
+            throw Error('[Debugger] Directory not set. Use youtube.debugger.setDirectory()');
+        }
+
+        let file = null;
+        let data = null;
+
+        switch (key) {
+            case 'opts':
+                file = join(this.dir, id + '-opts.json');
+                data = JSON.stringify(_data, null, 2);
+                break;
+            case 'page':
+                file = join(this.dir, id + '-page.html');
+                data = _data;
+                break;
+            case 'vids':
+                file = join(this.dir, id + '-vids.json');
+                data = JSON.stringify(_data, null, 2);
+                break;
+        }
+
+        if (file && data) {
+            writeFileSync(file, data);
+            console.log(`[Debugger] Wrote data to ${file}`);
+        } else console.log('[Debugger] Failed to prepare file or data');
+    }
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -9,6 +9,13 @@ export enum ResultType {
     live = 'live'
 }
 
+export interface DebugData {
+    options?: SearchOptions;
+    results?: Results;
+    page?: string;
+    timestamp?: string;
+}
+
 export interface SearchOptions {
     type?: ResultType | string;
     /**
@@ -20,6 +27,8 @@ export interface SearchOptions {
      */
     requestOptions?: RequestOptions;
 
+    /** ID used when debugging. Do not change */
+    _debugid?: string;
 }
 
 export const ResultFilter: { [key in ResultType]: string } = {


### PR DESCRIPTION
Added an advanced debugger that will, when enabled, write 3 files per search to a directory of choice.  
  
Some issues (#22 #31 #34) require me to see the raw HTML of the page to figure out what's going wrong, this should make things easier in the future.  

It can be enabled using:  

```javascript  
youtube.debug = true; // Enable regular debugging
youtube.debugger.enabled = true; // Enable debug dumps
youtube.debugger.setDirectory('path/to/somewhere'); // Directory to write the dumps  
```